### PR TITLE
Potential fix for micronaut repository compile error

### DIFF
--- a/buy-oyc-api-service/pom.xml
+++ b/buy-oyc-api-service/pom.xml
@@ -241,7 +241,7 @@
                                 <annotationProcessorPath>
                                     <groupId>io.micronaut.data</groupId>
                                     <artifactId>micronaut-data-processor</artifactId>
-                                    <version>${micronaut.version}</version>
+                                    <version>${micronaut.data.version}</version>
                                 </annotationProcessorPath>
                                 <annotationProcessorPath>
                                     <groupId>io.micronaut</groupId>

--- a/buy-oyc-catering-service/pom.xml
+++ b/buy-oyc-catering-service/pom.xml
@@ -234,7 +234,7 @@
                                 <path>
                                     <groupId>io.micronaut.data</groupId>
                                     <artifactId>micronaut-data-processor</artifactId>
-                                    <version>${micronaut.version}</version>
+                                    <version>${micronaut.data.version}</version>
                                 </path>
                                 <annotationProcessorPath>
                                     <groupId>io.micronaut</groupId>

--- a/buy-oyc-commons/pom.xml
+++ b/buy-oyc-commons/pom.xml
@@ -220,7 +220,7 @@
                                 <annotationProcessorPath>
                                     <groupId>io.micronaut.data</groupId>
                                     <artifactId>micronaut-data-processor</artifactId>
-                                    <version>${micronaut.version}</version>
+                                    <version>${micronaut.data.version}</version>
                                 </annotationProcessorPath>
                                 <annotationProcessorPath>
                                     <groupId>io.micronaut</groupId>
@@ -479,7 +479,7 @@
                                         <annotationProcessorPath>
                                             <groupId>io.micronaut.data</groupId>
                                             <artifactId>micronaut-data-processor</artifactId>
-                                            <version>${micronaut.version}</version>
+                                            <version>${micronaut.data.version}</version>
                                         </annotationProcessorPath>
                                         <annotationProcessorPath>
                                             <groupId>io.micronaut</groupId>

--- a/buy-oyc-concert-service/pom.xml
+++ b/buy-oyc-concert-service/pom.xml
@@ -243,7 +243,7 @@
                                 <path>
                                     <groupId>io.micronaut.data</groupId>
                                     <artifactId>micronaut-data-processor</artifactId>
-                                    <version>${micronaut.version}</version>
+                                    <version>${micronaut.data.version}</version>
                                 </path>
                                 <annotationProcessorPath>
                                     <groupId>io.micronaut</groupId>

--- a/buy-oyc-parking-service/pom.xml
+++ b/buy-oyc-parking-service/pom.xml
@@ -242,7 +242,7 @@
                                 <path>
                                     <groupId>io.micronaut.data</groupId>
                                     <artifactId>micronaut-data-processor</artifactId>
-                                    <version>${micronaut.version}</version>
+                                    <version>${micronaut.data.version}</version>
                                 </path>
                                 <annotationProcessorPath>
                                     <groupId>io.micronaut</groupId>

--- a/buy-oyc-ticket-service/pom.xml
+++ b/buy-oyc-ticket-service/pom.xml
@@ -231,7 +231,7 @@
                                 <annotationProcessorPath>
                                     <groupId>io.micronaut.data</groupId>
                                     <artifactId>micronaut-data-processor</artifactId>
-                                    <version>${micronaut.version}</version>
+                                    <version>${micronaut.data.version}</version>
                                 </annotationProcessorPath>
                                 <annotationProcessorPath>
                                     <groupId>io.micronaut</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <lettuce-core.version>6.2.1.RELEASE</lettuce-core.version>
 
         <micronaut.version>3.7.2</micronaut.version>
+        <micronaut.data.version>3.8.1</micronaut.data.version>
         <micronaut.openapi.version>4.0.0</micronaut.openapi.version>
         <micronaut.runtime>netty</micronaut.runtime>
         <micronaut-maven-plugin.version>3.5.0</micronaut-maven-plugin.version>


### PR DESCRIPTION
@jesperancinha I think this would fix compile error related to repository.exists method. There were changes in micronaut-data-processor module in 3.8.1 and pom.xml refers to `micronaut.version` instead of `micronaut.data.version` for micronaut-data-processor so it gets 3.7.0 instead of 3.8.1
I think latest micronaut launch refers to `micronaut.data.version` in micronaut-data-processor dependency and this should be applied to your project created earlier.
So with this, compile of commons module is passing but then another error related to OpenApi fails to compile but I guess someone else can look at that, I am not familiar with it 